### PR TITLE
Add Shops Compatibility

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -18,6 +18,13 @@ RegisterNetEvent(CurrentResourceName..'client:OpenStash', function(name)
     end
 end)
 
+RegisterNetEvent(CurrentResourceName..'client:OpenShop', function(name)
+    if not ox_inventory:openInventory('shop', { type = name }) then
+        TriggerServerEvent(CurrentResourceName..'server:RegisterShop', name)
+        ox_inventory:openInventory('shop', { type = name })
+    end
+end)
+
 RegisterNetEvent(CurrentResourceName..'client:OpenOtherInventory', function(name)
     -- if GetInvokingResource() ~= CurrentResourceName then return end
     if not name then

--- a/server/main.lua
+++ b/server/main.lua
@@ -380,6 +380,8 @@ local function RegisterShop(name, label, items)
 	-- check if the shop is a job shop and add the job to the groups (only accessible by the job)
 	if QBCore.Shared.Jobs[name] then
 		groups[name] = 0
+	else
+		groups = nil
 	end
 
 	-- register the shop


### PR DESCRIPTION
Guided by OX Inventory documentation (https://overextended.dev/ox_inventory/Guides/shops), I added the shops compatibility that was missing. This was tested and was working well with the latest versions of OX Inventory and QBCore.